### PR TITLE
Fix example so it can be compile using `jai example.jai` when in the examples folder

### DIFF
--- a/modules/enet/examples/example.jai
+++ b/modules/enet/examples/example.jai
@@ -1,4 +1,4 @@
-enet :: #import "enet";
+enet :: #import,dir "../../enet";
 #import "Basic";
 
 main :: () {


### PR DESCRIPTION
Thanks for your work on this repo! While testing it I found the example does not work out of the box because the module cannot be found:

```
C:\Users\matij\Documents\Dev\enet-jai\modules\enet\examples>jai -version    
Version: beta 0.1.081, built on 31 December 2023.

C:\Users\matij\Documents\Dev\enet-jai\modules\enet\examples>jai example.jai 

In Workspace 2 ("Target Program"):
C:/Users/matij/Documents/Dev/enet-jai/modules/enet/examples/example.jai:1,9: Error: Unable to find a module called 'enet' in any of the module search directories.

    enet :: #import "enet";

Info: ... Searched path 'C:/Users/matij/Documents/Dev/enet-jai/modules/enet/examples/modules'.      
Info: ... Searched path 'C:/Users/matij/Dropbox/jai/modules/'.
```

I guess the pattern of putting an `examples` folder under the module folder is based on what is done in the modules distributed with the compiler, for those modules it works because the compiler's modules folder is in the default search path.