### PR TITLE
Refactored logging and removed DEBUG_PRINT module parameter

### DIFF
--- a/enet/examples/example.jai
+++ b/enet/examples/example.jai
@@ -15,7 +15,7 @@ main :: () {
     }
 
     if !enet.initialize() {
-        print("Failed to initialize enet\n");
+        log_error("Failed to initialize enet");
         return;
     }
     defer enet.deinitialize();
@@ -35,12 +35,12 @@ run_server :: () {
 
     host, success := enet.host_create(*address, MAX_CLIENTS, 10, 0, 0);
     if !success {
-        print("Failed to create server\n");
+        log_error("Failed to create server");
         return;
     }
     defer enet.host_destroy(host);
 
-    print("Server started...\n");
+    log("Server started...");
 
     while true {
         event: enet.Event;
@@ -50,21 +50,21 @@ run_server :: () {
 
             if event.type == {
                 case .CONNECT;
-                    print("Connected client % on connection %\n", sender_address, event.peer.connect_id);
+                    log("Connected client % on connection %", sender_address, event.peer.connect_id);
 
                 case .RECEIVE;
                     msg: string = .{event.packet.data_length, event.packet.data};
-                    print("Server recieved message \"%\" on connection %\n", msg, event.peer.connect_id);
+                    log("Server recieved message \"%\" on connection %", msg, event.peer.connect_id);
                     enet.packet_destroy(event.packet);
 
                 case .DISCONNECT;
-                    print("Disconnected client % on connection %\n", sender_address, event.peer.connect_id);
+                    log("Disconnected client % on connection %", sender_address, event.peer.connect_id);
 
-                case .DISCONNECT_TIMEOUT; 
-                    print("Disconnected (timeout) client % on connection %\n", sender_address, event.peer.connect_id);
+                case .DISCONNECT_TIMEOUT;
+                    log("Disconnected (timeout) client % on connection %", sender_address, event.peer.connect_id);
 
                 case;
-                    print("Received event %\n", event.type);
+                    log("Received event %", event.type);
             }
         }
 
@@ -83,8 +83,8 @@ run_client :: () {
     log("Running as CLIENT");
 
     client, success := enet.host_create(null, 1, 10, 0, 0);
-    if !success { 
-        print("Failed to create client\n");
+    if !success {
+        log_error("Failed to create client");
         return;
     }
     defer enet.host_destroy(client);
@@ -92,7 +92,7 @@ run_client :: () {
     address := enet.get_host_ip_address(SERVER_ADDRESS);
     address.port = SERVER_PORT;
 
-    print("Connecting to server %:%\n", SERVER_ADDRESS, SERVER_PORT);
+    log("Connecting to server %:%", SERVER_ADDRESS, SERVER_PORT);
     server := enet.host_connect(client, *address, 1, 5);
 
     disconnect_countdown := 10;
@@ -104,24 +104,24 @@ run_client :: () {
         while enet.host_service(client, *event, WAIT_FOR_PACKETS_MS) == .SUCCESS {
             if event.type == {
                 case .CONNECT;
-                    print("Connected to server via connection %\n", event.peer.connect_id);
+                    log("Connected to server via connection %", event.peer.connect_id);
                     connected = true;
 
                 case .RECEIVE;
                     msg: string = .{event.packet.data_length, event.packet.data};
-                    print("Client recieved message \"%\" on connection %\n", msg, event.peer.connect_id);
+                    log("Client recieved message \"%\" on connection %", msg, event.peer.connect_id);
                     enet.packet_destroy(event.packet);
 
                 case .DISCONNECT;
-                    print("Connection % disconnected\n", event.peer.connect_id);
+                    log("Connection % disconnected", event.peer.connect_id);
                     break running;
 
                 case .DISCONNECT_TIMEOUT;
-                    print("Connection % disconnected (timeout)\n", event.peer.connect_id);
+                    log("Connection % disconnected (timeout)", event.peer.connect_id);
                     break running;
 
                 case;
-                    print("Received event %\n", event.type);
+                    log("Received event %", event.type);
             }
         }
 

--- a/enet/host.jai
+++ b/enet/host.jai
@@ -217,9 +217,7 @@ host_service :: (host: *Host, event: *Event, timeout: s64) -> Result_Status {
                 case .SUCCESS;
                     `return .SUCCESS;
                 case .ERROR;
-                    #if DEBUG_PRINT {
-                        log_error("Error sending outgoing packets\n");
-                    }
+                    log_error("Error sending outgoing packets");
                     `return .ERROR;
             }
         }
@@ -231,9 +229,7 @@ host_service :: (host: *Host, event: *Event, timeout: s64) -> Result_Status {
             case .SUCCESS; 
                 return .SUCCESS;
             case .ERROR;
-                #if DEBUG_PRINT {
-                    log_error("Error receiving incoming packets\n");
-                }
+                log_error("Error receiving incoming packets");
                 return .ERROR;
         }
 
@@ -245,9 +241,7 @@ host_service :: (host: *Host, event: *Event, timeout: s64) -> Result_Status {
                 case .SUCCESS; 
                     return .SUCCESS;
                 case .ERROR;
-                    #if DEBUG_PRINT {
-                        log_error("Error dispatching incoming commands\n");
-                    }
+                    log_error("Error dispatching incoming commands");
                     return .ERROR;
             }
         }

--- a/enet/module.jai
+++ b/enet/module.jai
@@ -1,4 +1,4 @@
-#module_parameters(DEBUG_FRAME_CAPTURE:=false, DEBUG_PRINT:=false);
+#module_parameters(DEBUG_FRAME_CAPTURE:=false);
 
 HOST_ANY :: V6_ANY_ADDR;
 
@@ -46,12 +46,12 @@ initialize :: () -> bool {
         wsa_data : WSAData;
 
         if WSAStartup(version, *wsa_data) {
-            log_error("Failed to initialize enet: Failed to startup WSA\n");
+            log_error("Failed to initialize enet: Failed to startup WSA");
             return false;
         }
 
         if wsa_data.wVersion & 1 != 1 || wsa_data.wVersion >> 8 != 1 {
-            log_error("Failed to initialize enet: Requested WSA version is % but got %\n", version, wsa_data.wVersion);
+            log_error("Failed to initialize enet: Requested WSA version is % but got %", version, wsa_data.wVersion);
             WSACleanup();
             return false;
         }

--- a/enet/protocol.jai
+++ b/enet/protocol.jai
@@ -246,13 +246,14 @@ protocol_send_outgoing_commands :: (host: *Host, event: *Event, check_for_timeou
                 packet_loss := peer.packets_lost * PEER_PACKET_LOSS_SCALE / peer.packets_sent; 
                 peer.packet_loss_variance -= peer.packet_loss_variance / 4;
 
-                #if DEBUG_PRINT {
+                if context.log_level >= .VERBOSE {
                     log("Peer % packets lost: % packet loss: % packet loss adjusted: % variance: %\n",
                         peer.incoming_peer_id,
                         peer.packets_lost,
                         packet_loss,
                         peer.packet_loss,
-                        peer.packet_loss_variance);
+                        peer.packet_loss_variance,
+                        flags=.VERBOSE_ONLY);
                 }
 
                 if packet_loss >= peer.packet_loss {
@@ -332,9 +333,7 @@ protocol_receive_incoming_commands :: (host: *Host, event: *Event) -> Result_Sta
             continue;
         }
         if received_length < 0 {
-            #if DEBUG_PRINT {
-                log_error("Socket error trying to receive packets: %\n, socket_error\n", socket_error);
-            }
+            log_error("Socket error trying to receive packets: %", socket_error);
             return .ERROR;
         }
         if received_length == 0 {
@@ -475,7 +474,7 @@ protocol_check_timeouts :: (host: *Host, peer: *Peer, event: *Event) -> bool {
             (outgoing_cmd.round_trip_timeout >= outgoing_cmd.round_trip_timeout_limit &&
             peer_timeout_time >= peer.timeout_minimum)) {
 
-            #if DEBUG_PRINT {
+            if context.log_level >= .VERBOSE {
                 log("Peer %: service_time: % peer timeout time: % (min: % max: %) round trip timeout: % / %\n", 
                     peer.incoming_peer_id,
                     host.service_time,
@@ -483,7 +482,8 @@ protocol_check_timeouts :: (host: *Host, peer: *Peer, event: *Event) -> bool {
                     peer.timeout_minimum,
                     peer.timeout_maximum,
                     outgoing_cmd.round_trip_timeout,
-                    outgoing_cmd.round_trip_timeout_limit);
+                    outgoing_cmd.round_trip_timeout_limit,
+                    flags=.VERBOSE_ONLY);
             }
 
             protocol_notify_disconnect_timeout(host, peer, event);
@@ -897,7 +897,7 @@ protocol_handle_incoming_commands :: (host: *Host, event: *Event) -> Result_Stat
 
     // @TODO :compression support
     // if flags & PROTOCOL_FLAG_COMPRESSED {
-    //     log_error("enet: compression is not yet supported\n");
+    //     log_error("enet: compression is not yet supported");
     // }
 
     // @TODO :checksum support

--- a/enet/socket.jai
+++ b/enet/socket.jai
@@ -216,9 +216,7 @@ socket_receive :: (socket: Socket, address: *Address, buffers: []Buffer, buffer_
                     return -2;
             }
 
-            #if DEBUG_PRINT {
-                log("Socket error from recvfrom %\n", error_no);
-            }
+            log_error("Socket error from recvfrom %", error_no);
             return -1, error_no;
         }
 


### PR DESCRIPTION
The idiomatic way to log nothing would be to push a do-nothing logger to a new context

I also removed the newlines at the end of log messages, these are not required (see how_to/350_logging)