### PR TITLE
Fix porting error: replace array_free with array_reset

### DIFF
--- a/enet/host.jai
+++ b/enet/host.jai
@@ -61,7 +61,7 @@ host_create :: (address: *Address, peer_count: int, channel_limit: int, incoming
         log_error("Failed to create and bind socket: %\n", WSAGetLastError());
 
         socket_destroy(host.socket);
-        array_free(host.peers);
+        array_reset(*host.peers);
         free(host);
 
         return host, false;
@@ -120,9 +120,9 @@ host_create :: (address: *Address, peer_count: int, channel_limit: int, incoming
 host_destroy :: (host: *Host) {
     socket_destroy(host.socket);
     for peer: host.peers  {
-        array_free(peer.channels);
+        array_reset(*peer.channels);
     }
-    array_free(host.peers);
+    array_reset(*host.peers);
     free(host);
 }
 

--- a/enet/peer.jai
+++ b/enet/peer.jai
@@ -329,7 +329,7 @@ peer_reset_queues :: (peer: *Peer) {
             peer_reset_incoming_commands(*channel.incoming_unreliable_commands);
         }
 
-        array_free(peer.channels);
+        array_reset(*peer.channels);
     }
 }
 
@@ -406,7 +406,7 @@ peer_receive :: (peer: *Peer, channel_id: *u8) -> *Packet {
     packet.ref_count -= 1;
 
     if incoming_cmd.fragments {
-        array_free(incoming_cmd.fragments);
+        array_reset(*incoming_cmd.fragments);
     }
 
     free(incoming_cmd);
@@ -788,7 +788,7 @@ peer_remove_incoming_commands :: (list: *List, start_cmd: *List_Node, end_cmd: *
             if incoming_cmd.packet.ref_count == 0 then packet_destroy(incoming_cmd.packet);
         }
 
-        if incoming_cmd.fragments.count > 0 then array_free(incoming_cmd.fragments);
+        if incoming_cmd.fragments.count > 0 then array_reset(*incoming_cmd.fragments);
 
         free(incoming_cmd);
     }

--- a/enet/protocol.jai
+++ b/enet/protocol.jai
@@ -759,7 +759,7 @@ protocol_handle_verify_connect :: (host: *Host, event: *Event, peer: *Peer, comm
     protocol_remove_sent_reliable_command(peer, 1, 0xFF);
 
     if channel_count < peer.channels.count {
-        array_free(peer.channels);
+        array_reset(*peer.channels);
         peer.channels = NewArray(channel_count, Channel);
 
         for * channel: peer.channels channel_reset(channel);


### PR DESCRIPTION
The array_reset function makes sure the counts are set to 0 as well. This fixes a regular crash I was getting in my game when I ran it with local client and server instances and then connected/reconnected a bunch. The problem I actually hit was related to peer.channels not calling array_reset, but from looking at the surrounding code in the other places I changed it I think they can/should also be changed to array_reset (if you know the code well, it would be great if you checked these too)