### PR TITLE
Fix peer_reset function (again)

### DIFF
--- a/enet/peer.jai
+++ b/enet/peer.jai
@@ -269,19 +269,22 @@ peer_timeout :: (peer: *Peer, timeout_limit: u32, timeout_min: u32, timeout_max:
 peer_reset :: (peer: *Peer) {
     peer_on_disconnect(peer);
 
-    // Hold onto the following data so they can be used when the disconnect event is sent
+    // Hold onto the following data e.g., so they can be used when the disconnect event is sent
     peer.* = Peer.{
-        connect_id       = peer.connect_id,
-        address          = peer.address,
-        host             = peer.host,
-        mtu              = peer.host.mtu,
-        data             = peer.data,
-        incoming_peer_id = peer.incoming_peer_id
+        connect_id          = peer.connect_id,
+        address             = peer.address,
+        host                = peer.host,
+        mtu                 = peer.host.mtu,
+        data                = peer.data,
+        incoming_peer_id    = peer.incoming_peer_id,
+        outgoing_session_id = peer.outgoing_session_id,
+        incoming_session_id = peer.incoming_session_id,
+        // These are used in peer_reset_queues below
+        channels            = peer.channels,
+        needs_dispatch      = peer.needs_dispatch
     };
 
     peer.state                        = .DISCONNECTED;
-    peer.outgoing_session_id          = 0xFF;
-    peer.incoming_session_id          = 0xFF;
     peer.outgoing_peer_id             = PROTOCOL_MAX_PEER_ID;
     peer.timeout_limit                = PEER_TIMEOUT_LIMIT;
     peer.timeout_minimum              = PEER_TIMEOUT_MINIMUM;


### PR DESCRIPTION
I added a comment to indicate why the channels and needs_dispatch flags need to be kept. Since this is the second time I'm fixing this function I reviewed the C-version https://github.com/zpl-c/enet again and found that int that code the incoming_session_id/outgoing_session_id members are also not overridden, but its not clear why... still, I guess this is a good enough reason to just keep them. I also checked the OG enet code from here: https://github.com/lsalzman/enet and that code also does not overwrite outgoingSessionID/incomingSessionID in peer_reset (or its callees).